### PR TITLE
remove pkg-resources from requirements.txt to fix issues#25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==6.6
 dateutils==0.6.6
 Mastodon.py==1.0.2
-pkg-resources==0.0.0
 python-dateutil==2.6.0
 pytz==2016.7
 requests==2.12.3


### PR DESCRIPTION
Hi! I thought this project is cool so I wanted to help out by picking up a fix to issue #25 

pkg-resources is not found in pip

By removing pkg-resources in requirements.txt I was able to install on Windows successfully