### PR TITLE
cmdline argument to use a nondefault config file

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -9,15 +9,12 @@ from mastodon import Mastodon
 from collections import OrderedDict
 
 
-#CONF_PATH = os.path.expanduser('~/.config/tootstream/')
-#CONF_FILE = "tootstream.conf"
-
 html_parser = HTMLParser()
 
 
 def parse_config(filename):
     (dirpath, basename) = os.path.split(filename)
-    if not os.path.exists(dirpath):
+    if not (dirpath == "" or os.path.exists(dirpath)):
         os.makedirs(dirpath)
 
     if not os.path.isfile(filename):
@@ -33,7 +30,7 @@ def parse_config(filename):
 
 def save_config(filename, instance, client_id, client_secret, token):
     (dirpath, basename) = os.path.split(filename)
-    if not os.path.exists(dirpath):
+    if not (dirpath == "" or os.path.exists(dirpath)):
         os.makedirs(dirpath)
     config = configparser.ConfigParser()
     config['default'] = {'instance':instance,

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -335,7 +335,7 @@ def authenticated(mastodon):
 @click.option('--password')
 @click.option('--config', '-c', type=click.Path(exists=False, readable=True), default='~/.config/tootstream/tootstream.conf')
 def main(instance, email, password, config):
-    configpath = config
+    configpath = os.path.expanduser(config)
     config = parse_config(configpath)
 
     if 'default' not in config:

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -9,17 +9,17 @@ from mastodon import Mastodon
 from collections import OrderedDict
 
 
-CONF_PATH = os.path.expanduser('~/.config/tootstream/')
-CONF_FILE = "tootstream.conf"
+#CONF_PATH = os.path.expanduser('~/.config/tootstream/')
+#CONF_FILE = "tootstream.conf"
 
 html_parser = HTMLParser()
 
 
-def parse_config():
-    if not os.path.exists(CONF_PATH):
-        os.makedirs(CONF_PATH)
+def parse_config(filename):
+    (dirpath, basename) = os.path.split(filename)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
 
-    filename = CONF_PATH + CONF_FILE
     if not os.path.isfile(filename):
         return {}
 
@@ -31,16 +31,17 @@ def parse_config():
 
     return config
 
-def save_config(instance, client_id, client_secret, token):
-    if not os.path.exists(CONF_PATH):
-        os.makedirs(CONF_PATH)
+def save_config(filename, instance, client_id, client_secret, token):
+    (dirpath, basename) = os.path.split(filename)
+    if not os.path.exists(dirpath):
+        os.makedirs(dirpath)
     config = configparser.ConfigParser()
     config['default'] = {'instance':instance,
                          'client_id':client_id,
                          'client_secret':client_secret,
                          'token':token}
 
-    with open(CONF_PATH + CONF_FILE, 'w') as configfile:
+    with open(filename, 'w') as configfile:
         config.write(configfile)
 
 def register_app(instance):
@@ -284,8 +285,10 @@ def authenticated(mastodon):
 @click.option('--instance')
 @click.option('--email')
 @click.option('--password')
-def main(instance, email, password):
-    config = parse_config()
+@click.option('--config', '-c', type=click.Path(exists=False, readable=True), default='~/.config/tootstream/tootstream.conf')
+def main(instance, email, password, config):
+    configpath = config
+    config = parse_config(configpath)
 
     if (not 'default' in config):
         config['default'] = {}
@@ -331,7 +334,7 @@ def main(instance, email, password):
             access_token = token,
             api_base_url = "https://" + instance)
 
-    save_config(instance, client_id, client_secret, token)
+    save_config(configpath, instance, client_id, client_secret, token)
 
     say_error = lambda a, b: tprint("Invalid command. Use 'help' for a \
                                     list of commands.")


### PR DESCRIPTION
This removes the hardcoded global configuration filename and provides a commandline switch (`-c` or `--config`, currently with hardcoded default) to allow loading configurations from alternate locations.  This is useful in testing or for storing configs for different instances in different files.  See issue #33

A future enhancement should remove the hardcoded path in favor of a crossplatform method, perhaps utilizing [`Click.get_app_dir()`](http://click.pocoo.org/5/api/#utilities).