### PR TITLE
get rid of escape keys in tootstream shell when using arrow keys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytz==2016.7
 requests==2.12.3
 six==1.10.0
 termcolor==1.1.0
+readline==6.2.4.1

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -5,6 +5,7 @@ import sys
 import re
 import configparser
 import random
+import readline
 from html.parser import HTMLParser
 from mastodon import Mastodon
 from collections import OrderedDict


### PR DESCRIPTION
simple fix by importing readline module