### PR TITLE
add short options, prettify help text

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -370,11 +370,18 @@ def authenticated(mastodon):
     return True
 
 
-@click.command()
-@click.option('--instance')
-@click.option('--email')
-@click.option('--password')
-@click.option('--config', '-c', type=click.Path(exists=False, readable=True), default='~/.config/tootstream/tootstream.conf')
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option( '--instance', '-i', metavar='<string>',
+               help='Hostname of the instance to connect' )
+@click.option( '--email', '-e', metavar='<string>',
+               help='Email to login' )
+@click.option( '--password', '-p', metavar='<PASSWD>',
+               help='Password to login (UNSAFE)' )
+@click.option( '--config', '-c', metavar='<file>',
+               type=click.Path(exists=False, readable=True),
+               default='~/.config/tootstream/tootstream.conf',
+               help='Location of alternate configuration file to load' )
 def main(instance, email, password, config):
     configpath = os.path.expanduser(config)
     config = parse_config(configpath)


### PR DESCRIPTION
pursuant to #47 this patch results in the following help text:

    $ python3 tootstream/toot.py -h
    Usage: toot.py [OPTIONS]
    
    Options:
      -i, --instance <string>  Hostname of the instance to connect
      -e, --email <string>     Email to login
      -p, --password <PASSWD>  Password to login (UNSAFE)
      -c, --config <file>      Location of alternate configuration file to load
      -h, --help               Show this message and exit.

should be easy to maintain and add new options in a similar format.

wording revisions on the help texts are welcome but i strongly encourage some warning to the user on the `--password` option.