### PR TITLE
Add support for 256 colors

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -9,7 +9,7 @@ import readline
 from toot_parser import TootParser
 from mastodon import Mastodon
 from collections import OrderedDict
-from termcolor import cprint
+from colored import fg, bg, attr, stylize
 
 COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white']
 
@@ -35,7 +35,7 @@ class IdDict:
         try:
             return self._map[local_id]
         except:
-            tprint('Invalid ID.', 'red', '')
+            cprint('Invalid ID.', fg('red'))
             return None
 
 IDS = IdDict();
@@ -101,13 +101,8 @@ def login(mastodon, instance, email, password):
 
     return mastodon.log_in(email, password)
 
-
-def tprint(text, color, bgColor):
-    printFn = lambda x: cprint(x, color)
-    if bgColor != "":
-        bg = 'on_' + bgColor
-        printFn = lambda x: cprint(x, color, bg)
-    printFn(text)
+def cprint(text, style, end="\n"):
+    print(stylize(text, style), end=end)
 
 
 #####################################
@@ -133,8 +128,8 @@ def help(mastodon, rest):
 def toot(mastodon, rest):
     """Publish a toot. ex: 'toot Hello World' will publish 'Hello World'."""
     mastodon.toot(rest)
-    cprint("You tooted: ", 'magenta', attrs=['bold'], end="")
-    cprint(rest, 'magenta', 'on_white', attrs=['bold', 'underline'])
+    cprint("You tooted: ", fg('magenta') + attr('bold'), end="")
+    cprint(rest, fg('magenta') + bg('white') + attr('bold') + attr('underlined'))
 
 
 @command
@@ -146,7 +141,7 @@ def boost(mastodon, rest):
     mastodon.status_reblog(rest)
     boosted = mastodon.status(rest)
     msg = "  Boosted: " + get_content(boosted)
-    tprint(msg, 'green', 'red')
+    cprint(msg, fg('green') + bg('red'))
 
 
 @command
@@ -158,7 +153,7 @@ def unboost(mastodon, rest):
     mastodon.status_unreblog(rest)
     unboosted = mastodon.status(rest)
     msg = "  Removed boost: " + get_content(unboosted)
-    tprint(msg, 'red', 'green')
+    cprint(msg, fg('red') + bg('green'))
 
 
 @command
@@ -170,7 +165,7 @@ def fav(mastodon, rest):
     mastodon.status_favourite(rest)
     faved = mastodon.status(rest)
     msg = "  Favorited: " + get_content(faved)
-    tprint(msg, 'red', 'yellow')
+    cprint(msg, fg('red') + bg('yellow'))
 
 @command
 def rep(mastodon, rest):
@@ -192,7 +187,7 @@ def rep(mastodon, rest):
     reply_toot = mastodon.status_post('%s %s' % (mentions, reply_text),
                                       in_reply_to_id=int(parent_id))
     msg = "  Replied with: " + get_content(reply_toot)
-    tprint(msg, 'red', 'yellow')
+    cprint(msg, fg('red') + bg('yellow'))
 
 @command
 def unfav(mastodon, rest):
@@ -203,7 +198,7 @@ def unfav(mastodon, rest):
     mastodon.status_unfavourite(rest)
     unfaved = mastodon.status(rest)
     msg = "  Removed favorite: " + get_content(unfaved)
-    tprint(msg, 'yellow', 'red')
+    cprint(msg, fg('yellow') + bg('red'))
 
 
 @command
@@ -218,19 +213,19 @@ def home(mastodon, rest):
 
         # Prints individual toot/tooter info
         random.seed(display_name)
-        cprint(display_name, random.choice(COLORS), end="")
-        cprint(username, 'green', end="")
-        cprint(toot['created_at'], 'grey')
+        cprint(display_name, fg(random.choice(COLORS)), end="")
+        cprint(username, fg('green'), end="")
+        cprint(toot['created_at'], attr('dim'))
 
-        cprint(reblogs_count, 'cyan', end="")
-        cprint(favourites_count, 'yellow', end="")
+        cprint(reblogs_count, fg('cyan'), end="")
+        cprint(favourites_count, fg('yellow'), end="")
         
-        cprint("id:" + toot_id, 'red')
+        cprint("id:" + toot_id, fg('red'))
 
         # Shows boosted toots as well
         if toot['reblog']:
             username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
-            cprint(username, 'blue', end='')
+            cprint(username, fg('blue'), end="")
             content = get_content(toot['reblog'])
         else:
             content = get_content(toot)
@@ -248,15 +243,15 @@ def public(mastodon, rest):
         toot_id = str(IDS.to_local(toot['id']))
 
         # Prints individual toot/tooter info
-        cprint(display_name, 'green', end="",)
-        cprint(username + toot['created_at'], 'yellow')
-        cprint(reblogs_count + favourites_count, 'cyan', end="")
-        cprint(toot_id, 'red', attrs=['bold'])
+        cprint(display_name, fg('green'), end="")
+        cprint(username + toot['created_at'], fg('yellow'))
+        cprint(reblogs_count + favourites_count, fg('cyan'), end="")
+        cprint(toot_id, fg('red') + attr('bold'))
 
         # Shows boosted toots as well
         if toot['reblog']:
             username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
-            cprint(username, 'blue', end='')
+            cprint(username, fg('blue'), end="")
             content = get_content(toot['reblog'])
         else:
             content = get_content(toot)
@@ -273,8 +268,8 @@ def note(mastodon, rest):
 
         # Mentions
         if note['type'] == 'mention':
-            tprint(display_name + username, 'magenta', '')
-            tprint(get_content(note['status']), 'magenta', '')
+            cprint(display_name + username, fg('magenta'))
+            cprint(get_content(note['status']), fg('magenta'))
 
         # Favorites
         elif note['type'] == 'favourite':
@@ -282,20 +277,20 @@ def note(mastodon, rest):
             favourites_count = " ♥:" + str(note['status']['favourites_count'])
             time = " " + note['status']['created_at']
             content = get_content(note['status'])
-            tprint(display_name + username + " favorited your status:", 'green', '')
-            tprint(reblogs_count + favourites_count + time + '\n' + content, 'green', '')
+            cprint(display_name + username + " favorited your status:", fg('green'))
+            cprint(reblogs_count + favourites_count + time + '\n' + content, fg('green'))
 
         # Boosts
         elif note['type'] == 'reblog':
-            tprint(display_name + username + " boosted your status:", 'yellow', '')
-            tprint(get_content(note['status']), 'yellow', '')
+            cprint(display_name + username + " boosted your status:", fg('yellow'))
+            cprint(get_content(note['status']), fg('yellow'))
 
         # Follows
         elif note['type'] == 'follow':
             username = re.sub('<[^<]+?>', '', username)
             display_name = note['account']['display_name']
-            cprint("  ", end="")
-            cprint(display_name + username + " followed you!", 'red', 'on_green')
+            print("  ", end="")
+            cprint(display_name + username + " followed you!", fg('red') + bg('green'))
 
         # blank line
         print('')
@@ -313,9 +308,9 @@ def info(mastodon, rest):
     user = mastodon.account_verify_credentials()
 
     print("@" + str(user['username']))
-    tprint(user['display_name'], 'cyan', 'red')
+    cprint(user['display_name'], fg('cyan') + bg('red'))
     print(user['url'])
-    tprint(re.sub('<[^<]+?>', '', user['note']), 'red', 'green')
+    cprint(re.sub('<[^<]+?>', '', user['note']), fg('red') + bg('green'))
 
 
 @command
@@ -422,10 +417,11 @@ def main(instance, email, password, config):
 
     save_config(configpath, instance, client_id, client_secret, token)
 
-    say_error = lambda a, b: tprint("Invalid command. Use 'help' for a list of commands.", 'white', 'red')
+    say_error = lambda a, b: cprint("Invalid command. Use 'help' for a list of commands.",
+            fg('white') + bg('red'))
 
     print("You are connected to ", end="")
-    cprint(instance, 'green', attrs=['bold'])
+    cprint(instance, fg('green') + attr('bold'))
     print("Enter a command. Use 'help' for a list of commands.")
     print("\n")
 


### PR DESCRIPTION
Switch from the termcolor library to the colored library which adds
support for extra colors on supported terminals.

This should also make it easier to move color/style choices into
variables to make the color scheme configurable (see issue #41)