### PR TITLE
initial support for profiles, cli option and load/create/delete/list commands

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -31,7 +31,7 @@ class IdDict:
     def to_global(self, local_id):
         """Returns the global ID for a local ID, or None if ID is invalid.
         Also prints an error message"""
-        local_id = int(local_id) 
+        local_id = int(local_id)
         try:
             return self._map[local_id]
         except:
@@ -57,7 +57,11 @@ def parse_config(filename):
         print("...No configuration found, generating...")
         return
 
-    cfg.read(filename)
+    try:
+        cfg.read(filename)
+    except configparser.Error:
+        cprint("This does not look like a valid configuration:"+filename, 'red')
+        sys.exit("Goodbye!")
 
 
 def save_config(filename):
@@ -65,8 +69,11 @@ def save_config(filename):
     if not (dirpath == "" or os.path.exists(dirpath)):
         os.makedirs(dirpath)
 
-    with open(filename, 'w') as configfile:
-        cfg.write(configfile)
+    try:
+        with open(filename, 'w') as configfile:
+            cfg.write(configfile)
+    except os.error:
+        cprint("Unable to write configuration to "+filename, 'red')
 
 
 def register_app(instance):
@@ -213,7 +220,7 @@ def home(mastodon, rest):
 
         cprint(reblogs_count, 'cyan', end="")
         cprint(favourites_count, 'yellow', end="")
-        
+
         cprint("id:" + toot_id, 'red')
 
         # Shows boosted toots as well
@@ -369,9 +376,11 @@ def authenticated(mastodon):
                help='Name of profile for saved credentials (default)' )
 def main(instance, email, password, config, profile):
     configpath = os.path.expanduser(config)
-    parse_config(configpath)
+    if os.path.isfile(configpath) and not os.access(configpath, os.W_OK):
+        # warn the user before they're asked for input
+        cprint("Config file does not appear to be writable: "+configpath, 'red')
 
-    #global cfg
+    parse_config(configpath)
     if not cfg.has_section(profile):
         cfg.add_section(profile)
 

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -117,7 +117,7 @@ def parse_config():
     try:
         cfg.read(filename)
     except configparser.Error:
-        cprint("This does not look like a valid configuration:"+filename, 'red')
+        cprint("This does not look like a valid configuration:"+filename, fg('red'))
         sys.exit("Goodbye!")
 
 
@@ -131,7 +131,7 @@ def save_config():
         with open(filename, 'w') as configfile:
             cfg.write(configfile)
     except os.error:
-        cprint("Unable to write configuration to "+filename, 'red')
+        cprint("Unable to write configuration to "+filename, fg('red'))
 
 
 def register_app(instance):
@@ -177,7 +177,7 @@ def parse_or_input_profile(profile, instance=None, email=None, password=None):
     elif "instance" in cfg[profile]:
         instance = cfg[profile]['instance']
     else:
-        cprint("  Which instance would you like to connect to? eg: 'mastodon.social'", 'blue')
+        cprint("  Which instance would you like to connect to? eg: 'mastodon.social'", fg('blue'))
         instance = input("  Instance: ")
 
 
@@ -223,8 +223,8 @@ def print_profiles():
         pass
     # TODO: wrap based on termwidth
     inactives = ' '.join(inactiveprofiles)
-    cprint("  *"+active, 'red', end="")
-    cprint("  "+inactives, 'blue')
+    cprint("  *"+active, fg('red'), end="")
+    cprint("  "+inactives, fg('blue'))
     return
 
 
@@ -355,7 +355,7 @@ def home(rest):
 
         cprint(reblogs_count, fg('cyan'), end="")
         cprint(favourites_count, fg('yellow'), end="")
-        
+
         cprint("id:" + toot_id, fg('red'))
 
         # Shows boosted toots as well
@@ -504,7 +504,7 @@ def profile(rest):
                 "         profile list")
 
     def profile_error(error):
-        cprint("  "+error, 'red')
+        cprint("  "+error, fg('red'))
         return
 
     try:
@@ -538,7 +538,7 @@ def profile(rest):
             set_prompt("[@" + str(user['username']) + " (" + profile + ")]: ")
             set_active_profile(profile)
             set_active_mastodon(newmasto)
-            cprint("  Profile " + profile + " loaded", 'green')
+            cprint("  Profile " + profile + " loaded", fg('green'))
             return
         else:
             profile_error("Profile " + profile + " doesn't seem to exist")
@@ -577,7 +577,7 @@ def profile(rest):
         set_prompt("[@" + str(user['username']) + " (" + profile + ")]: ")
         set_active_profile(profile)
         set_active_mastodon(newmasto)
-        cprint("  Profile " + profile + " loaded", 'green')
+        cprint("  Profile " + profile + " loaded", fg('green'))
         return
     # end new/create
 
@@ -590,7 +590,7 @@ def profile(rest):
 
         cfg.remove_section(profile)
         save_config()
-        cprint("  Poof! It's gone.", 'blue')
+        cprint("  Poof! It's gone.", fg('blue'))
         if profile == get_active_profile():
             set_active_profile("")
         return
@@ -603,7 +603,7 @@ def profile(rest):
     # end list
 
     # no subcommand; print usage
-    cprint(usage, 'red')
+    cprint(usage, fg('red'))
     return
 
 
@@ -638,7 +638,7 @@ def main(instance, email, password, config, profile):
     configpath = os.path.expanduser(config)
     if os.path.isfile(configpath) and not os.access(configpath, os.W_OK):
         # warn the user before they're asked for input
-        cprint("Config file does not appear to be writable: "+configpath, 'red')
+        cprint("Config file does not appear to be writable: "+configpath, fg('red'))
 
     set_configfile(configpath)
     parse_config()
@@ -669,7 +669,7 @@ def main(instance, email, password, config, profile):
     say_error = lambda a, b: cprint("Invalid command. Use 'help' for a list of commands.",
             fg('white') + bg('red'))
 
-    cprint("Welcome to tootstream! Two-Factor-Authentication is currently not supported.", 'blue')
+    cprint("Welcome to tootstream! Two-Factor-Authentication is currently not supported.", fg('blue'))
     print("You are connected to ", end="")
     cprint(instance, fg('green') + attr('bold'))
     print("Enter a command. Use 'help' for a list of commands.")

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -448,6 +448,7 @@ def info(rest):
 @command
 def delete(rest):
     """Deletes your toot by ID"""
+    global mastodon
     rest = IDS.to_global(rest)
     if rest is None:
         return
@@ -651,7 +652,7 @@ def main(instance, email, password, config, profile):
     save_config()
 
 
-    say_error = lambda a, b: tprint("Invalid command. Use 'help' for a list of commands.", 'white', 'red')
+    say_error = lambda a: tprint("Invalid command. Use 'help' for a list of commands.", 'white', 'red')
 
     cprint("Welcome to tootstream! Two-Factor-Authentication is currently not supported.", 'blue')
     print("You are connected to ", end="")

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -83,6 +83,12 @@ def get_active_profile():
     return click.get_current_context().meta.get(KEYPROFILE)
 
 
+def get_profile_values(profile):
+    # quick return of existing profile, watch out for exceptions
+    p = cfg[profile]
+    return p['instance'], p['client_id'], p['client_secret'], p['token']
+
+
 def parse_config():
     filename = get_configfile()
     (dirpath, basename) = os.path.split(filename)
@@ -135,9 +141,18 @@ def login(mastodon, instance, email, password):
     return mastodon.log_in(email, password)
 
 
-#client_id, client_secret, token = parse_or_input_profile(profile, instance, email, password)
 def parse_or_input_profile(profile, instance=None, email=None, password=None):
-    # validate a profile, request user input as necessary
+    """
+    Validate an existing profile or get user input to generate a new one.
+    """
+    # shortcut for preexisting profiles
+    if cfg.has_section(profile):
+        try:
+            return get_profile_values(profile)
+        except:
+            pass
+
+    # no existing profile or it's incomplete
     if (instance != None):
         # Nothing to do, just use value passed on the command line
         pass

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -12,6 +12,11 @@ from collections import OrderedDict
 from termcolor import cprint
 
 COLORS = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white']
+RESERVED = ( "theme" )
+KEYCFGFILE = __name__ + 'cfgfile'
+KEYPROFILE = __name__ + 'profile'
+KEYPROMPT = __name__ + 'prompt'
+
 
 class IdDict:
     """Represents a mapping of local (tootstream) ID's to global
@@ -38,9 +43,11 @@ class IdDict:
             tprint('Invalid ID.', 'red', '')
             return None
 
+
 IDS = IdDict();
 cfg = configparser.ConfigParser()
 toot_parser = TootParser(indent='  ')
+
 
 def get_content(toot):
     html = toot['content']
@@ -48,7 +55,36 @@ def get_content(toot):
     toot_parser.feed(html)
     return toot_parser.get_text()
 
-def parse_config(filename):
+
+def set_configfile(filename):
+    click.get_current_context().meta[KEYCFGFILE] = filename
+    return
+
+
+def get_configfile():
+    return click.get_current_context().meta.get(KEYCFGFILE)
+
+
+def set_prompt(prompt):
+    click.get_current_context().meta[KEYPROMPT] = prompt
+    return
+
+
+def get_prompt():
+    return click.get_current_context().meta.get(KEYPROMPT)
+
+
+def set_active_profile(profile):
+    click.get_current_context().meta[KEYPROFILE] = profile
+    return
+
+
+def get_active_profile():
+    return click.get_current_context().meta.get(KEYPROFILE)
+
+
+def parse_config():
+    filename = get_configfile()
     (dirpath, basename) = os.path.split(filename)
     if not (dirpath == "" or os.path.exists(dirpath)):
         os.makedirs(dirpath)
@@ -64,7 +100,8 @@ def parse_config(filename):
         sys.exit("Goodbye!")
 
 
-def save_config(filename):
+def save_config():
+    filename = get_configfile()
     (dirpath, basename) = os.path.split(filename)
     if not (dirpath == "" or os.path.exists(dirpath)):
         os.makedirs(dirpath)
@@ -424,7 +461,8 @@ def main(instance, email, password, config, profile):
         # warn the user before they're asked for input
         cprint("Config file does not appear to be writable: "+configpath, 'red')
 
-    parse_config(configpath)
+    set_configfile(configpath)
+    parse_config()
     if not cfg.has_section(profile):
         cfg.add_section(profile)
 
@@ -444,7 +482,8 @@ def main(instance, email, password, config, profile):
         'token': token
     }
 
-    save_config(configpath)
+    set_active_profile(profile)
+    save_config()
 
 
     say_error = lambda a, b: tprint("Invalid command. Use 'help' for a list of commands.", 'white', 'red')
@@ -456,10 +495,10 @@ def main(instance, email, password, config, profile):
     print("\n")
 
     user = mastodon.account_verify_credentials()
-    prompt = "[@" + str(user['username']) + "]: "
+    set_prompt("[@" + str(user['username']) + "@" + instance + "]: ")
 
     while True:
-        command = input(prompt).split(' ', 1)
+        command = input(get_prompt()).split(' ', 1)
         rest = ""
         try:
             rest = command[1]


### PR DESCRIPTION
this patch adds initial support for profiles including specifying with `--profile`.  an example REPL command for changing profiles on the fly is stubbed but not yet implemented; i'd like some feedback on #50 in regards to what that command should look like.