### PR TITLE
upgrade Mastodon.py to 1.0.6, add "local" subcommand

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==6.6
 dateutils==0.6.6
-Mastodon.py==1.0.2
+Mastodon.py==1.0.6
 python-dateutil==2.6.0
 pytz==2016.7
 requests==2.12.3

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -239,8 +239,35 @@ def home(mastodon, rest):
 
 @command
 def public(mastodon, rest):
-    """Displays the Public timeline."""
+    """Displays the Public (federated) timeline."""
     for toot in reversed(mastodon.timeline_public()):
+        display_name = "  " + toot['account']['display_name']
+        username = " @" + toot['account']['username'] + " "
+        reblogs_count = "  ♺:" + str(toot['reblogs_count'])
+        favourites_count = " ♥:" + str(toot['favourites_count']) + " "
+        toot_id = str(IDS.to_local(toot['id']))
+
+        # Prints individual toot/tooter info
+        cprint(display_name, 'green', end="",)
+        cprint(username + toot['created_at'], 'yellow')
+        cprint(reblogs_count + favourites_count, 'cyan', end="")
+        cprint(toot_id, 'red', attrs=['bold'])
+
+        # Shows boosted toots as well
+        if toot['reblog']:
+            username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
+            cprint(username, 'blue', end='')
+            content = get_content(toot['reblog'])
+        else:
+            content = get_content(toot)
+
+        print(content + "\n")
+
+
+@command
+def local(mastodon, rest):
+    """Displays the Local (instance) timeline."""
+    for toot in reversed(mastodon.timeline_local()):
         display_name = "  " + toot['account']['display_name']
         username = " @" + toot['account']['username'] + " "
         reblogs_count = "  ♺:" + str(toot['reblogs_count'])

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -271,15 +271,15 @@ def local(mastodon, rest):
         toot_id = str(IDS.to_local(toot['id']))
 
         # Prints individual toot/tooter info
-        cprint(display_name, 'green', end="",)
-        cprint(username + toot['created_at'], 'yellow')
-        cprint(reblogs_count + favourites_count, 'cyan', end="")
-        cprint(toot_id, 'red', attrs=['bold'])
+        cprint(display_name, fg('green'), end="")
+        cprint(username + toot['created_at'], fg('yellow'))
+        cprint(reblogs_count + favourites_count, fg('cyan'), end="")
+        cprint(toot_id, fg('red') + attr('bold'))
 
         # Shows boosted toots as well
         if toot['reblog']:
             username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
-            cprint(username, 'blue', end='')
+            cprint(username, fg('blue'), end="")
             content = get_content(toot['reblog'])
         else:
             content = get_content(toot)


### PR DESCRIPTION
the current version of Mastodon.py (1.0.2) doesn't provide the local timeline but later versions do.  this patch upgrades the dependency to 1.0.6 and adds the `local` command to the REPL.  #55 

this change needs testing to make sure the dependency change doesn't break existing functions.