### PR TITLE
add "search #tagname/@username" command

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -277,7 +277,7 @@ def search(mastodon, rest):
         indicator = rest[:1]
         query = rest[1:]
     except:
-        cprint(usage, 'red')
+        cprint(usage, fg('red'))
         return
 
     # @ user search
@@ -298,15 +298,15 @@ def search(mastodon, rest):
             toot_id = str(IDS.to_local(toot['id']))
 
             # Prints individual toot/tooter info
-            cprint(display_name, 'green', end="",)
-            cprint(username + toot['created_at'], 'yellow')
-            cprint(reblogs_count + favourites_count, 'cyan', end="")
-            cprint(toot_id, 'red', attrs=['bold'])
+            cprint(display_name, fg('green'), end="",)
+            cprint(username + toot['created_at'], fg('yellow'))
+            cprint(reblogs_count + favourites_count, fg('cyan'), end="")
+            cprint(toot_id, fg('red'), attrs=['bold'])
 
             # Shows boosted toots as well
             if toot['reblog']:
                 username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
-                cprint(username, 'blue', end='')
+                cprint(username, fg('blue'), end='')
                 content = get_content(toot['reblog'])
             else:
                 content = get_content(toot)
@@ -315,7 +315,7 @@ def search(mastodon, rest):
     # end #
 
     else:
-        cprint("  Invalid format.\n"+usage, 'red')
+        cprint("  Invalid format.\n"+usage, fg('red'))
 
     return
 

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -110,6 +110,14 @@ def tprint(text, color, bgColor):
     printFn(text)
 
 
+def printUser(user):
+    """Prints user data nicely with hardcoded colors."""
+    print("@" + str(user['username']))
+    tprint(user['display_name'], 'cyan', 'red')
+    print(user['url'])
+    tprint(re.sub('<[^<]+?>', '', user['note']), 'red', 'green')
+
+
 #####################################
 ######## BEGIN COMMAND BLOCK ########
 #####################################
@@ -271,19 +279,22 @@ def search(mastodon, rest):
                  "         search @username" )
     try:
         indicator = rest[:1]
-        search = rest[1:]
+        query = rest[1:]
     except:
         cprint(usage, 'red')
         return
 
     # @ user search
-    if indicator == "@" and not search == "":
-        cprint("  User search is not yet implemented.", 'red')
+    if indicator == "@" and not query == "":
+        users = mastodon.account_search(query)
+
+        for user in users:
+            printUser(user)
     # end @
 
     # # hashtag search
-    elif indicator == "#" and not search == "":
-        for toot in reversed(mastodon.timeline_hashtag(search)):
+    elif indicator == "#" and not query == "":
+        for toot in reversed(mastodon.timeline_hashtag(query)):
             display_name = "  " + toot['account']['display_name']
             username = " @" + toot['account']['username'] + " "
             reblogs_count = "  ♺:" + str(toot['reblogs_count'])
@@ -361,11 +372,7 @@ def quit(mastodon, rest):
 def info(mastodon, rest):
     """Prints your user info."""
     user = mastodon.account_verify_credentials()
-
-    print("@" + str(user['username']))
-    tprint(user['display_name'], 'cyan', 'red')
-    print(user['url'])
-    tprint(re.sub('<[^<]+?>', '', user['note']), 'red', 'green')
+    printUser(user)
 
 
 @command

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -31,7 +31,7 @@ class IdDict:
     def to_global(self, local_id):
         """Returns the global ID for a local ID, or None if ID is invalid.
         Also prints an error message"""
-        local_id = int(local_id) 
+        local_id = int(local_id)
         try:
             return self._map[local_id]
         except:
@@ -224,7 +224,7 @@ def home(mastodon, rest):
 
         cprint(reblogs_count, 'cyan', end="")
         cprint(favourites_count, 'yellow', end="")
-        
+
         cprint("id:" + toot_id, 'red')
 
         # Shows boosted toots as well
@@ -262,6 +262,56 @@ def public(mastodon, rest):
             content = get_content(toot)
 
         print(content + "\n")
+
+
+@command
+def search(mastodon, rest):
+    """Search for a #tag or @user."""
+    usage = str( "  usage: search #tagname\n" +
+                 "         search @username" )
+    try:
+        indicator = rest[:1]
+        search = rest[1:]
+    except:
+        cprint(usage, 'red')
+        return
+
+    # @ user search
+    if indicator == "@" and not search == "":
+        cprint("  User search is not yet implemented.", 'red')
+    # end @
+
+    # # hashtag search
+    elif indicator == "#" and not search == "":
+        for toot in reversed(mastodon.timeline_hashtag(search)):
+            display_name = "  " + toot['account']['display_name']
+            username = " @" + toot['account']['username'] + " "
+            reblogs_count = "  ♺:" + str(toot['reblogs_count'])
+            favourites_count = " ♥:" + str(toot['favourites_count']) + " "
+            toot_id = str(IDS.to_local(toot['id']))
+
+            # Prints individual toot/tooter info
+            cprint(display_name, 'green', end="",)
+            cprint(username + toot['created_at'], 'yellow')
+            cprint(reblogs_count + favourites_count, 'cyan', end="")
+            cprint(toot_id, 'red', attrs=['bold'])
+
+            # Shows boosted toots as well
+            if toot['reblog']:
+                username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
+                cprint(username, 'blue', end='')
+                content = get_content(toot['reblog'])
+            else:
+                content = get_content(toot)
+
+            print(content + "\n")
+    # end #
+
+    else:
+        cprint("  Invalid format.\n"+usage, 'red')
+
+    return
+
 
 
 @command


### PR DESCRIPTION
adds hashtag search. see #8 .  specifically this patch adds a `search` command to the REPL that takes one argument.  arguments starting with `#` are searched as hashtags; with `@` are searched as usernames.  hashtag search results are printed with the same code as the `public` command, so it can be refactored easily when #53 is merged.  user search results are printed with the same code as the `info` command and has been refactored.

commands as proposed:

* `search #tagname`
* `search @username`
