### PR TITLE
language detection and filtering toots based on language

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.12.3
 six==1.10.0
 termcolor==1.1.0
 readline==6.2.4.1
+langdetect==1.0.7

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -306,6 +306,46 @@ def quit(mastodon, rest):
     """Ends the program."""
     sys.exit("Goodbye!")
 
+@command
+def view(mastodon, rest):
+    """Show toot and all its parent toots"""
+    try:
+        rest = IDS.to_global(rest)
+        if rest is None: return
+
+        while True:
+            toot = mastodon.status(rest)
+
+            # display the toot as with the public() command (TODO: should make a function)
+            display_name = "  " + toot['account']['display_name']
+            username = " @" + toot['account']['username'] + " "
+            reblogs_count = "  ♺:" + str(toot['reblogs_count'])
+            favourites_count = " ♥:" + str(toot['favourites_count']) + " "
+            toot_id = str(IDS.to_local(toot['id']))
+
+            # Prints individual toot/tooter info
+            cprint(display_name, 'green', end="",)
+            cprint(username + toot['created_at'], 'yellow')
+            cprint(reblogs_count + favourites_count, 'cyan', end="")
+            cprint(toot_id, 'red', attrs=['bold'])
+
+            # Shows boosted toots as well
+            if toot['reblog']:
+                username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
+                cprint(username, 'blue', end='')
+                content = get_content(toot['reblog'])
+            else:
+                content = get_content(toot)
+            print("="*80+"\n")
+            print(content + "\n")
+
+            rest=toot['in_reply_to_id']
+            print("parent toot: "+str(rest))
+            if rest==None: break
+
+    except:
+        print("WARNING: should be followed by a toot ID")
+        return
 
 @command
 def info(mastodon, rest):

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -329,61 +329,6 @@ def quit(mastodon, rest):
     sys.exit("Goodbye!")
 
 @command
-def details(mastodon, rest):
-    """Show detailed toot"""
-    try:
-        rest = IDS.to_global(rest)
-        if rest is None: return
-
-        toot = mastodon.status(rest)
-        print(toot)
-
-    except:
-        print("WARNING: should be followed by a toot ID")
-        return
-
-@command
-def view(mastodon, rest):
-    """Show toot and all its parent toots"""
-    try:
-        rest = IDS.to_global(rest)
-        if rest is None: return
-
-        while True:
-            toot = mastodon.status(rest)
-
-            # display the toot as with the public() command (TODO: should make a function)
-            display_name = "  " + toot['account']['display_name']
-            username = " @" + toot['account']['username'] + " "
-            reblogs_count = "  ♺:" + str(toot['reblogs_count'])
-            favourites_count = " ♥:" + str(toot['favourites_count']) + " "
-            toot_id = str(IDS.to_local(toot['id']))
-
-            # Prints individual toot/tooter info
-            cprint(display_name, 'green', end="",)
-            cprint(username + toot['created_at'], 'yellow')
-            cprint(reblogs_count + favourites_count, 'cyan', end="")
-            cprint(toot_id, 'red', attrs=['bold'])
-
-            # Shows boosted toots as well
-            if toot['reblog']:
-                username = "  Boosted @" + toot['reblog']['account']['acct'] +": "
-                cprint(username, 'blue', end='')
-                content = get_content(toot['reblog'])
-            else:
-                content = get_content(toot)
-            print("="*80+"\n")
-            print(content + "\n")
-
-            rest=toot['in_reply_to_id']
-            print("parent toot: "+str(rest))
-            if rest==None: break
-
-    except:
-        print("WARNING: should be followed by a toot ID")
-        return
-
-@command
 def info(mastodon, rest):
     """Prints your user info."""
     user = mastodon.account_verify_credentials()


### PR DESCRIPTION
In this PR, I just keep the language detection part (and removed all my other stuff), so:
- it detects language from toot content
- it displays the detected language next to the "favorites count"
- it proposes the "lang" command with which we can specify the language we only want to see on the public timeline, with 2-letter code or "all" to clear the list and see all toots again
