### PR TITLE
add cmds: followers, following, blocks, mutes, requests

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -102,8 +102,26 @@ def login(mastodon, instance, email, password):
 
     return mastodon.log_in(email, password)
 
+
 def cprint(text, style, end="\n"):
     print(stylize(text, style), end=end)
+
+
+def printUsersShort(users):
+    for user in users:
+        if not user: continue
+        locked = ""
+        # lock glyphs: masto web uses FontAwesome's U+F023 (nonstandard)
+        # lock emoji: U+1F512
+        if user['locked']: locked = " \U0001f512"
+        userstr = "@"+str(user['acct'])+locked
+        userid = "(id:"+str(user['id'])+")"
+        userdisp = "'"+str(user['display_name'])+"'"
+        userurl = str(user['url'])
+        cprint("  "+userstr, fg('green'), end=" ")
+        cprint(" "+userid, fg('red'), end=" ")
+        cprint(" "+userdisp, fg('cyan'))
+        cprint("      "+userurl, fg('blue'))
 
 
 #####################################

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -366,6 +366,52 @@ def unfollow(mastodon, rest):
     # TODO: Find out how to get global usernames
 
 
+@command
+def followers(mastodon, rest):
+    """Lists users who follow you."""
+    user = mastodon.account_verify_credentials()
+    users = mastodon.account_followers(user['id'])
+    if not users:
+        cprint("  You don't have any followers", fg('red'))
+    else:
+        cprint("  Your followers:", fg('magenta'))
+        printUsersShort(users)
+
+
+@command
+def following(mastodon, rest):
+    """Lists users you follow."""
+    user = mastodon.account_verify_credentials()
+    users = mastodon.account_following(user['id'])
+    if not users:
+        cprint("  You're safe!  There's nobody following you", fg('red'))
+    else:
+        cprint("  People following you:", fg('magenta'))
+        printUsersShort(users)
+
+
+@command
+def blocks(mastodon, rest):
+    """Lists users you have blocked."""
+    users = mastodon.blocks()
+    if not users:
+        cprint("  You haven't blocked anyone (... yet)", fg('red'))
+    else:
+        cprint("  You have blocked:", fg('magenta'))
+        printUsersShort(users)
+
+
+@command
+def mutes(mastodon, rest):
+    """Lists users you have muted."""
+    users = mastodon.mutes()
+    if not users:
+        cprint("  You haven't muted anyone (... yet)", fg('red'))
+    else:
+        cprint("  You have muted:", fg('magenta'))
+        printUsersShort(users)
+
+
 #####################################
 ######### END COMMAND BLOCK #########
 #####################################

--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -412,6 +412,19 @@ def mutes(mastodon, rest):
         printUsersShort(users)
 
 
+@command
+def requests(mastodon, rest):
+    """Lists your incoming follow requests."""
+    users = mastodon.follow_requests()
+    if not users:
+        cprint("  You have no incoming requests", fg('red'))
+    else:
+        cprint("  These users want to follow you:", fg('magenta'))
+        printUsersShort(users)
+        cprint("  run 'accept <id>' to accept", fg('magenta'))
+        cprint("   or 'reject <id>' to reject", fg('magenta'))
+
+
 #####################################
 ######### END COMMAND BLOCK #########
 #####################################


### PR DESCRIPTION
add commands to the REPL to list users that you block, mute, or follow, or that follow you or have requested to follow you (for locked accounts).  prints users in a compressed 2-line format that shows only account (user@instance), id\#, display name, and account url.  ~~see PR #71 for commands to manipulate these lists.~~

(un)follow/(un)block commands fulfill issues #15, #16.  these and (un)mute work with the argument given as userID, @user, and user@instance. non-userIDs must be searched, and if the search returns multiple values this will display those to the user and return to the prompt.

proposed commands:

* `followers`
* `following`
* `blocks`
* `mutes`
* `requests`
* `follow/unfollow`
* `block/unblock`
* `mute/unmute`
* `accept/reject`

edit: note `blocks`, `mutes`, and `requests` are not supported in Mastodon.py v1.0.2. (provided in v1.0.6.)