### PR TITLE
add cli argument --profile

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -16,6 +16,9 @@ from colored import fg, bg, attr, stylize
 #TODO: Set color list in config file
 COLORS = list(range(19,231))
 
+# reserved config sections (disallowed as profile names)
+RESERVED = ( "theme", "global" )
+
 
 class IdDict:
     """Represents a mapping of local (tootstream) ID's to global
@@ -167,7 +170,7 @@ def login(instance, client_id, client_secret, email, password):
     return mastodon.log_in(email, password)
 
 
-def get_or_input_profile(config, instance=None, email=None, password=None):
+def get_or_input_profile(config, profile, instance=None, email=None, password=None):
     """
     Validate an existing profile or get user input
     to generate a new one.  If email/password is
@@ -179,35 +182,35 @@ def get_or_input_profile(config, instance=None, email=None, password=None):
     On failure, returns None, None, None, None.
     """
     # shortcut for preexisting profiles
-    if config.has_section('default'):
+    if config.has_section(profile):
         try:
-            return  config['default']['instance'], \
-                    config['default']['client_id'], \
-                    config['default']['client_secret'], \
-                    config['default']['token']
+            return  config[profile]['instance'], \
+                    config[profile]['client_id'], \
+                    config[profile]['client_secret'], \
+                    config[profile]['token']
         except:
             pass
     else:
-        config.add_section('default')
+        config.add_section(profile)
 
     # no existing profile or it's incomplete
     if (instance != None):
         # Nothing to do, just use value passed on the command line
         pass
-    elif "instance" in config['default']:
-        instance = config['default']['instance']
+    elif "instance" in config[profile]:
+        instance = config[profile]['instance']
     else:
         cprint("  Which instance would you like to connect to? eg: 'mastodon.social'", fg('blue'))
         instance = input("  Instance: ")
 
 
     client_id = None
-    if "client_id" in config['default']:
-        client_id = config['default']['client_id']
+    if "client_id" in config[profile]:
+        client_id = config[profile]['client_id']
 
     client_secret = None
-    if "client_secret" in config['default']:
-        client_secret = config['default']['client_secret']
+    if "client_secret" in config[profile]:
+        client_secret = config[profile]['client_secret']
 
     if (client_id == None or client_secret == None):
         try:
@@ -217,8 +220,8 @@ def get_or_input_profile(config, instance=None, email=None, password=None):
             return None, None, None, None
 
     token = None
-    if "token" in config['default']:
-        token = config['default']['token']
+    if "token" in config[profile]:
+        token = config[profile]['token']
 
     if (token == None or email != None or password != None):
         for i in [1, 2, 3]:
@@ -931,7 +934,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                type=click.Path(exists=False, readable=True),
                default='~/.config/tootstream/tootstream.conf',
                help='Location of alternate configuration file to load' )
-def main(instance, email, password, config):
+@click.option( '--profile', '-P', metavar='<profile>', default='default',
+               help='Name of profile for saved credentials (default)' )
+def main(instance, email, password, config, profile):
     configpath = os.path.expanduser(config)
     if os.path.isfile(configpath) and not os.access(configpath, os.W_OK):
         # warn the user before they're asked for input
@@ -939,11 +944,18 @@ def main(instance, email, password, config):
 
     config = parse_config(configpath)
 
-    if 'default' not in config:
-        config['default'] = {}
+    # make sure profile name is legal
+    profile = re.sub(r'\s+', '', profile)  # disallow whitespace
+    profile = profile.lower()              # force to lowercase
+    if profile == '' or profile in RESERVED:
+        cprint("Invalid profile name: {}".format(profile), fg('red'))
+        sys.exit(1)
+
+    if not config.has_section(profile):
+        config.add_section(profile)
 
     instance, client_id, client_secret, token = \
-                            get_or_input_profile(config, instance, email, password)
+                            get_or_input_profile(config, profile, instance, email, password)
 
     if not token:
         cprint("Could not log you in.  Please try again later.", fg('red'))
@@ -956,8 +968,8 @@ def main(instance, email, password, config):
         api_base_url="https://" + instance)
 
     # update config before writing
-    if "token" not in config['default']:
-        config['default'] = {
+    if "token" not in config[profile]:
+        config[profile] = {
                 'instance': instance,
                 'client_id': client_id,
                 'client_secret': client_secret,
@@ -975,7 +987,7 @@ def main(instance, email, password, config):
     print("\n")
 
     user = mastodon.account_verify_credentials()
-    prompt = "[@" + str(user['username']) + "]: "
+    prompt = "[@{} ({})]: ".format(str(user['username']), profile)
 
     while True:
         command = input(prompt).split(' ', 1)


### PR DESCRIPTION
reimplementation of #51 (cli option only) on current dev branch.

* login-related user prompts are moved into a reusable utility function.   more error checking, retry login in case of connection trouble or user typos (exit with error after 3 failures).
* profile names are restricted.  no whitespace, case-insensitive, check against the reserved list.  exit with error if profile name provided is invalid.
* `RESERVED` list is intended for config section names the program wants for other purposes.  add or change as needed.

