### PR TITLE
fix get_userid

### DIFF
--- a/tootstream/toot.py
+++ b/tootstream/toot.py
@@ -107,6 +107,22 @@ def get_userid(mastodon, rest):
     if not users:
         return -1
     elif len(users) > 1:
+        # Mastodon's search is fuzzier than we want; check for exact match
+
+        query = (rest[1:] if rest.startswith('@') else rest)
+        (quser, _, qinstance) = query.partition('@')
+        localinstance = mastodon.instance()
+
+        # on uptodate servers, exact match should be first in list
+        for user in users:
+            # match user@remoteinstance, localuser
+            if query == user['acct']:
+                return user['id']
+            # match user@localinstance
+            elif quser == user['acct'] and qinstance == localinstance['uri']:
+                return user['id']
+
+        # no exact match; return list
         return users
     else:
         return users[0]['id']


### PR DESCRIPTION
this refines the `get_userid()` helper to handle the Mastodon search API's fuzziness.  this should fix the issue noted by @magicalraccoon in #102 for all commands that use the helper.

* `get_userid`: check API results list for exact match to user input
* this handles the Mastodon search's tendency to return extra data
on user search.  Mastodon commit 9642601 (in v1.4.1 and later)
should ensure an exact match is first in the list.  there are cases
in earlier server versions where the search could fail to return
an existing exact match, but these should be rare.  see
https://github.com/tootsuite/mastodon/issues/3064