### PR TITLE
Make Python 3 requirement more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tootstream
 
-A command line interface for interacting with Mastodon instances written in python.
+A command line interface for interacting with Mastodon instances written in Python (requires Python 3).
 
 OAuth and 2FA are supported.
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 setup(
     name="tootstream",
     version="0.3.0rc1",
+    python_requires=">=3",
     install_requires=[line.strip() for line in open('requirements.txt')],
 
     packages=find_packages('src'),


### PR DESCRIPTION
If you try to install tootstream under Python 2, it will look like it
installed but then immediately throw an exception upon running due to
non-ASCII characters in the source code. Specify Python 3 earlier in the
README and specify `python_requires` in `setup.py` so it checks the
Python version in the installation process.