### PR TITLE
Stylize mentions and attach full account and id

### DIFF
--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -90,6 +90,7 @@ toot_listener = TootListener()
 def get_content(toot):
     html = toot['content']
     toot_parser.reset()
+    toot_parser.set_mentions(toot.get('mentions'))
     toot_parser.feed(html)
     toot_parser.close()
     return toot_parser.get_text()

--- a/src/tootstream/toot_parser.py
+++ b/src/tootstream/toot_parser.py
@@ -1,5 +1,39 @@
 from html.parser import HTMLParser
 from textwrap import TextWrapper
+from colored import fg, stylize
+
+def extract_mention_url(attrs):
+    """
+    Takes a list of (key, value) attribute pairs like the one given in
+    HTMLParser for an <a> tag, and determine whether this <a> tag is a mention.
+    If so, return the href value, which is the URL of the user's profile;
+    otherwise return None.
+    """
+    is_mention = False
+    href = None
+    for key, value in attrs:
+        if key == 'class' and 'mention' in value.split():
+            is_mention = True
+        elif key == 'href':
+            href = value
+    if is_mention:
+        return href
+    else:
+        return None
+
+def get_text_for_mention(mention):
+    """
+    Given a mention dict as provided by mastodon.py, format it as text.
+    Returns None if the mention does not exist or does not contain an
+    account for some reason.
+    """
+
+    if mention is None: return None
+    acct = mention.get('acct')
+    if acct is None: return None
+    acct_text = stylize('@' + acct, fg('green'))
+    id_text = stylize('(id:{})'.format(mention.get('id', '?')), fg('red'))
+    return acct_text + ' ' + id_text
 
 class TootParser(HTMLParser):
     def __init__(self,
@@ -10,6 +44,11 @@ class TootParser(HTMLParser):
         self.reset()
         self.strict = False
         self.convert_charrefs = True
+
+        # We'll decide how to format mentions based on the tag attributes
+        # alone, so we set this flag to remember to ignore the text encountered
+        # inside the tag.
+        self.in_mention = False
 
         self.indent = indent
 
@@ -27,20 +66,41 @@ class TootParser(HTMLParser):
         self.lines = []
         self.cur_type = None
 
+    def set_mentions(self, mentions):
+        self.mentions = dict()
+        if mentions:
+            for mention in mentions:
+                url = mention.get('url')
+                if url is not None:
+                    self.mentions[url] = mention
+
     def pop_line(self):
         line = ''.join(self.fed)
         self.fed = []
         return line
 
     def handle_data(self, data):
-        self.fed.append(data)
+        if not self.in_mention:
+            self.fed.append(data)
 
     def handle_starttag(self, tag, attrs):
         if tag == 'br':
             self.lines.append(self.pop_line())
-        if tag == 'p' and len(self.fed) > 0:
+        elif tag == 'p' and len(self.fed) > 0:
             self.lines.append(self.pop_line())
             self.lines.append('')
+        elif tag == 'a':
+            mentioned_href = extract_mention_url(attrs)
+            if mentioned_href is not None:
+                mention = self.mentions.get(mentioned_href, dict())
+                text = get_text_for_mention(mention)
+                if text is not None:
+                    self.fed.append(text)
+                    self.in_mention = True
+
+    def handle_endtag(self, tag):
+        if tag == 'a':
+            self.in_mention = False
 
     def get_text(self):
         self.lines.append(self.pop_line())


### PR DESCRIPTION
When printing mentions in toots, use the `mentions` dict to get the full
account name (including instance domain) and id, so that the account can
be unambiguously specified. Print both of them stylized.

<img width="616" alt="screen shot 2017-11-13 at 6 00 56 pm" src="https://user-images.githubusercontent.com/3482833/32753892-aa7bdc7c-c89c-11e7-95c5-a3f35bff6f3a.png">