### PR TITLE
New toot_parser features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click>=6.7
 Mastodon.py==1.1.2
 colored>=1.3.5
 humanize>=0.5.1
+emoji>=0.4.5

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -89,9 +89,7 @@ toot_listener = TootListener()
 #####################################
 def get_content(toot):
     html = toot['content']
-    toot_parser.reset()
-    toot_parser.feed(html)
-    toot_parser.close()
+    toot_parser.parse(html)
     return toot_parser.get_text()
 
 

--- a/src/tootstream/toot_parser.py
+++ b/src/tootstream/toot_parser.py
@@ -1,10 +1,96 @@
+import emoji
+from colored import attr
 from html.parser import HTMLParser
 from textwrap import TextWrapper
 
+
+def convert_emoji_shortcodes(text):
+    """Convert standard emoji short codes to unicode emoji in
+    the provided text.
+
+      text - The text to parse.
+      Returns the modified text.
+    """
+    return emoji.emojize(text, use_aliases = True)
+
+
+def find_attr(name, attrs):
+    """Find an attribute in an HTML tag by name.
+
+      name - The attribute name to search for.
+      attrs - The list of attributes to search.
+      Returns the matching attribute or None.
+    """
+    for attr, values in attrs:
+        if attr == name:
+            return values
+    return None
+
+
+def has_class(value, attrs):
+    """Return whether the HTML attributes contain a specific class name.
+
+      value - The class type to search for.
+      attrs - The list of attributes to search.
+      Returns true if the specified class type was found.
+    """
+    values = find_attr('class', attrs)
+    if values is None:
+        return False
+
+    return values.find(value) >= 0
+
+
 class TootParser(HTMLParser):
+    """
+    TootParser is used to parse HTML based toots and convert them into
+    plain text versions.  By default the returned text is equivalent to the
+    source toot text with paragraph and br tags converted to line breaks.
+
+    The text can optionally be indented by passing a string to the indent
+    field which is prepended to every line in the source text.
+
+    The text can also have text wrapping enabled by passing in a max width to
+    the width parameter.  Note that the text wrapping is not perfect right
+    now and doesn't work well with terminal colors and a lot of unicode text
+    on one line.
+
+    Link shortening can be enabled by setting the shorten_links parameter.
+    This shortens links by using the link shortening helper HTML embedded in
+    the source toot.  This means links embedded from sources other than
+    mastodon may not be shortened.  The shortened urls will look like
+    example.org/areallylongur...
+
+    Emoji short codes can optionally be converted into unicode based emoji by
+    enabling the convert_emoji parameter.  This parses standard emoji short
+    code names and does not support custom emojo short codes.
+
+    Styles can also optionally be applied to links found in the source text.
+    Pass in the desired colored style to the link_style, mention_style, and
+    hashtag_style parameters.
+
+    To parse a toot, pass the toot source HTML to the parse() command. The
+    source text can then be retrieved with the get_text() command.  Parsed
+    link urls can also be retrieved by calling the get_links() command.
+
+      indent - A string to prepend to all lines in the output text.
+      width - The maximum number of characters to allow in a line of text.
+      shorten_links - Whether or not to shorten links.
+      convert_emoji - Whether or not to convert emoji short codes to unicode.
+      link_style - The colored style to apply to generic links.
+      mention_style - The colored style to apply to mentions.
+      hashtag_style - The colored style to apply to hashtags.
+
+    """
+
     def __init__(self,
             indent = '',
-            width = 0):
+            width = 0,
+            convert_emoji = False,
+            shorten_links = False,
+            link_style = None,
+            mention_style = None,
+            hashtag_style = None):
 
         super().__init__()
         self.reset()
@@ -12,6 +98,11 @@ class TootParser(HTMLParser):
         self.convert_charrefs = True
 
         self.indent = indent
+        self.convert_emoji = convert_emoji
+        self.shorten_links = shorten_links
+        self.link_style = link_style
+        self.mention_style = mention_style
+        self.hashtag_style = hashtag_style
 
         if width > 0:
             self.wrap = TextWrapper()
@@ -21,38 +112,157 @@ class TootParser(HTMLParser):
         else:
             self.wrap = None
 
+
     def reset(self):
+        """Resets the parser so a new toot can be parsed."""
         super().reset()
         self.fed = []
         self.lines = []
+        self.links = []
         self.cur_type = None
+        self.hide = False
+        self.ellipsis = False
+
 
     def pop_line(self):
+        """Take the current text scratchpad and return it as a
+        line of text and reset the scratchpad."""
         line = ''.join(self.fed)
         self.fed = []
         return line
 
+
     def handle_data(self, data):
+        """Processes plain text data.
+          data - The text to process
+        """
+        if self.hide:
+            return
+
+        if self.convert_emoji:
+            data = convert_emoji_shortcodes(data)
+
         self.fed.append(data)
 
+
+    def parse_link(self, attrs):
+        """Processes a link tag.
+          attrs - A list of attributes contained in the link tag.
+        """
+
+        # Save the link url
+        self.links.append(find_attr('href', attrs))
+
+        if has_class('hashtag', attrs):
+            self.cur_type = 'hashtag'
+            if self.hashtag_style != None:
+                self.fed.append(self.hashtag_style)
+        elif has_class('mention', attrs):
+            self.cur_type = 'mention'
+            if self.mention_style != None:
+                self.fed.append(self.mention_style)
+        else:
+            self.cur_type = 'link'
+            if self.link_style != None:
+                self.fed.append(self.link_style)
+
+
+    def parse_span(self, attrs):
+        """Processes a span tag.
+          attrs - A list of attributes contained in the span tag.
+        """
+
+        # Right now we only support spans used to shorten links.
+        # Mastodon links contain <span class="hidden"> tags around
+        # text that should be omitted in the shorted link version
+        # and <span class="ellipsis"> tags around text that should
+        # be terminated with an ellipsis.
+        if not self.shorten_links or self.cur_type != 'link':
+            return
+
+        if has_class('invisible', attrs):
+            # Mark that any text in the tag should be omitted
+            self.hide = True
+
+        elif has_class('ellipsis', attrs):
+            # Mark the any text in the tag should be terminated
+            # with ellipsis
+            self.ellipsis = True
+
+
     def handle_starttag(self, tag, attrs):
-        if tag == 'br':
+        """Parses a new HTML tag.
+          tag - The name of the new tag.
+          attrs - The attributes contained in the tag.
+        """
+        if tag == 'a':
+            self.parse_link(attrs)
+
+        elif tag == 'span':
+            self.parse_span(attrs)
+
+        elif tag == 'br':
             self.lines.append(self.pop_line())
-        if tag == 'p' and len(self.fed) > 0:
+
+        elif tag == 'p' and len(self.fed) > 0:
             self.lines.append(self.pop_line())
             self.lines.append('')
 
+
+    def handle_endtag(self, tag):
+        """Parses a closing tag.
+          tag - The tag to parse.
+        """
+        if tag == 'a':
+            # Reset if we are applying a style
+            if ((self.cur_type == 'link' and self.link_style != None) or
+                (self.cur_type == 'mention' and self.mention_style != None) or
+                (self.cur_type == 'hashtag' and self.hashtag_style != None)):
+                self.fed.append(attr('reset'))
+
+            # Only types associated with 'a' tags are tracked at the moment
+            self.cur_type = None
+
+        if tag == 'span' and self.hide:
+            # Allow text to be shown now that the hide span
+            # has finished
+            self.hide = False
+
+        if tag == 'span' and self.ellipsis:
+            # Add ellipsis to the text if we have finished a
+            # <span class="ellipsis"> tag.
+            self.fed.append('...')
+            self.ellipsis = False
+
+
+    def parse(self, html):
+        """Parses a single source toot.
+          html - The source HTML of the toot.
+        """
+        self.reset()
+        self.feed(html)
+        self.close()
+
+
     def get_text(self):
+        """Returns a plain text version of the source HTML toot."""
+
+        # Add the last line from the scratchpad.
         self.lines.append(self.pop_line())
 
         if self.wrap == None:
             return self.indent + ('\n' + self.indent).join(self.lines)
 
+        # Text wrap the lines by feeding them to TextWrapper first.
         out = []
         for line in self.lines:
             if len(line) == 0:
                 out.append(line)
             else:
                 out.append(self.wrap.fill(line))
-
         return '\n'.join(out)
+
+
+    def get_links(self):
+        """Returns an array of links parsed from the source HTML toot."""
+        return self.links


### PR DESCRIPTION
Hi!  I've had these toot_parser features lying around for a while and I finally got a chance to clean them up.  This adds a few new features to toot parser that aren't yet enabled in tootstream.

**link/mention/hashtag styles** - Styles can be passed in to toot parser to change the color/style of links, mentions, and hashtags.

**retrieving links from a toot** - Toot parser will generate a list of urls found in the source toot that can be retrieved with get_links()

**emoji short code conversion** - Standard emoji short codes can be converted into unicode emoji by using https://github.com/carpedm20/emoji/

**link shortening** - Mastodon shortens links by embedding span tags that hide certain parts of the link and adds ellipsis to the end of the link.  Toot parser now supports shortening links using this method.