### PR TITLE
Add links command to print urls in a toot

### DIFF
--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -927,6 +927,33 @@ thread.__section__ = 'Toots'
 
 
 @command
+def links(mastodon, rest):
+    """Show the urls of any links, hashtags, or mentions by ID.
+
+    ex: links 23"""
+
+    status_id = IDS.to_global(rest)
+    if status_id is None:
+        return
+
+    try:
+        toot = mastodon.status(status_id)
+        toot_parser.parse(toot['content'])
+        links = toot_parser.get_links()
+
+        for link in links:
+            print(link)
+
+    except Exception as e:
+        cprint("{}: please try again later".format(
+            type(e).__name__),
+            fg('red'))
+
+links.__argstr__ = '<id>'
+links.__section__ = 'Toots'
+
+
+@command
 def home(mastodon, rest):
     """Displays the Home timeline."""
     for toot in reversed(mastodon.timeline_home()):


### PR DESCRIPTION
This adds a 'links' command that takes an id and prints out any links contained in the source toot.  This also includes links to hashtag pages and account pages.

Example output:

> [@erinolivia (default)]: links 16
https://github.com/magicalraccoon/tootstream
[@erinolivia (default)]: links 9
https://mastodon.art/tags/commission
https://mastodon.art/tags/mastoart
https://mastodon.art/tags/art
https://mastodon.art/tags/creativetoots
[@erinolivia (default)]: links 12
https://awoo.space/@erinolivia
[@erinolivia (default)]: