### PR TITLE
Fixed toot boost output

### DIFF
--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -891,7 +891,7 @@ def boost(mastodon, rest):
     try:
         mastodon.status_reblog(rest)
         boosted = mastodon.status(rest)
-        msg = "  You boosted: ", fg('white') + get_content(boosted)
+        msg = "  You boosted: " + fg('white') + get_content(boosted)
         cprint(msg, fg('green'))
     except Exception as e:
         cprint("Received error: ", fg('red') + attr('bold'), end="")


### PR DESCRIPTION
It wasn't concatenating(?) correctly. It would come out as `('  You boosted: ', '\x1b[38;5;15m  toot')`