### PR TITLE
Add browse command to let users open toots in their web browser

### DIFF
--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1071,13 +1071,18 @@ links.__section__ = 'Toots'
 
 @command
 def web(mastodon, rest):
-    """Open links from a toot in the default webbrowser.
+    """Open toot in default webbrowser. See `help web` for more options.
+
+    Add `gui` parameter to open toot in the Mastodon web user interface. 
+    Add `pub` parameter to open shareable public toot URL. 
+    Add `all` parameter to open all contained links in separate browser tabs.
 
     Examples:
         >>> web 23      # defaults to the first link found
         >>> web 23 2    # open second link
         >>> web 23 all  # open all links
-        >>> web 23 toot # open original web url of toot 
+        >>> web 23 pub  # open public web url of toot 
+        >>> web 23 gui  # open toot in mastodon web gui
     """
 
     args = rest.split(' ')
@@ -1087,11 +1092,14 @@ def web(mastodon, rest):
         return
 
     link_num = 1
+    open_all = False
     if len(args) == 2 and len(args[1]) > 0:
         if args[1] == 'all':
-            link_num = -1
-        elif args[1] == 'toot':
+            open_all = True
+        elif args[1] == 'pub':
             link_num = 0
+        elif args[1] == 'gui':
+            link_num = -1
         else:
             link_num = int(args[1])
             link_num = link_num if link_num >= 0 else 1
@@ -1105,11 +1113,18 @@ def web(mastodon, rest):
             type(e).__name__),
             fg('red'))
 
+    # Open public toot URL
     if link_num == 0 or len(links) == 0:
         links = [toot.url]
-        link_num = -1
+        open_all = True
 
+    # Open toot in web gui
     if link_num == -1:
+        links = ["/".join(
+            [mastodon.api_base_url, "web", "statuses", str(toot.id)])]
+        open_all = True
+
+    if open_all:
         for link in links:
             webbrowser.open(link)
     else:

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1095,7 +1095,7 @@ def web(mastodon, rest):
     try:
         toot = mastodon.status(status_id)
         toot_parser.parse(toot['content'])
-        links = toot_parser.weblinks
+        links = toot_parser.get_weblinks()
 
     except Exception as e:
         cprint("{}: please try again later".format(

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1097,6 +1097,40 @@ links.__section__ = 'Toots'
 
 
 @command
+def browse(mastodon, rest):
+    """Open toot in browser. Use `browse <id> in client` to open Mastodon GUI.
+
+    Examples:
+        >>> browse 23
+        >>> browse 23 in client
+    """
+
+    args = rest.split(' ', 1)
+
+    status_id = IDS.to_global(args[0])
+    if status_id is None:
+        return
+    
+    try:
+        toot = mastodon.status(status_id)
+    except Exception as e:
+        cprint("{}: please try again later".format(
+            type(e).__name__),
+            fg('red'))
+    else:
+        if len(args) > 1 and args[1] == 'in client':
+            url = "/".join(
+                [mastodon.api_base_url, "web", "statuses", str(toot.id)])
+        else:
+            url = toot.url
+
+        webbrowser.open(url)
+
+browse.__argstr__ = '<id>'
+browse.__section__ = 'Toots'
+
+
+@command
 def home(mastodon, rest):
     """Displays the Home timeline."""
     for toot in reversed(mastodon.timeline_home()):

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1074,9 +1074,11 @@ def web(mastodon, rest):
     """Open links from a toot in the default webbrowser.
 
     Examples:
-        >>> links 23      # defaults to the first link found
-        >>> links 23 2    # open second link
-        >>> links 23 all  # open all links """
+        >>> web 23      # defaults to the first link found
+        >>> web 23 2    # open second link
+        >>> web 23 all  # open all links
+        >>> web 23 toot # open original web url of toot 
+    """
 
     args = rest.split(' ')
 
@@ -1088,19 +1090,24 @@ def web(mastodon, rest):
     if len(args) == 2 and len(args[1]) > 0:
         if args[1] == 'all':
             link_num = -1
+        elif args[1] == 'toot':
+            link_num = 0
         else:
             link_num = int(args[1])
-            link_num = link_num if link_num > 0 else 1
+            link_num = link_num if link_num >= 0 else 1
 
     try:
         toot = mastodon.status(status_id)
         toot_parser.parse(toot['content'])
         links = toot_parser.get_weblinks()
-
     except Exception as e:
         cprint("{}: please try again later".format(
             type(e).__name__),
             fg('red'))
+
+    if link_num == 0 or len(links) == 0:
+        links = [toot.url]
+        link_num = -1
 
     if link_num == -1:
         for link in links:

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -16,6 +16,7 @@ import datetime
 import dateutil
 import shutil
 import emoji
+import webbrowser
 
 # Get the version of Tootstream
 import pkg_resources  # part of setuptools
@@ -1067,6 +1068,55 @@ def links(mastodon, rest):
 
 links.__argstr__ = '<id>'
 links.__section__ = 'Toots'
+
+@command
+def web(mastodon, rest):
+    """Open links from a toot in the default webbrowser.
+
+    Examples:
+        >>> links 23      # defaults to the first link found
+        >>> links 23 2    # open second link
+        >>> links 23 all  # open all links """
+
+    args = rest.split(' ')
+
+    status_id = IDS.to_global(args[0])
+    if status_id is None:
+        return
+
+    link_num = 1
+    if len(args) == 2:
+        if args[1] == 'all':
+            link_num = -1
+        else:
+            link_num = int(args[1])
+            link_num = link_num if link_num > 0 else 1
+
+    try:
+        toot = mastodon.status(status_id)
+        toot_parser.parse(toot['content'])
+        links = toot_parser.weblinks
+
+        if link_num == -1:
+            for link in links:
+                webbrowser.open(link)
+        else:
+            if len(links) < link_num:
+                cprint("Cannot open link {}. Toot contains {} weblinks".format(
+                    link_num, len(links)), fg('red'))
+                return
+
+            webbrowser.open(links[link_num - 1])
+
+    except Exception as e:
+        cprint("{}: please try again later".format(
+            type(e).__name__),
+            fg('red'))
+
+web.__argstr__ = '<id>'
+web.__section__ = 'Toots'
+
+
 
 
 @command

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1085,7 +1085,7 @@ def web(mastodon, rest):
         return
 
     link_num = 1
-    if len(args) == 2:
+    if len(args) == 2 and len(args[1]) > 0:
         if args[1] == 'all':
             link_num = -1
         else:

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -1097,21 +1097,21 @@ def web(mastodon, rest):
         toot_parser.parse(toot['content'])
         links = toot_parser.weblinks
 
-        if link_num == -1:
-            for link in links:
-                webbrowser.open(link)
-        else:
-            if len(links) < link_num:
-                cprint("Cannot open link {}. Toot contains {} weblinks".format(
-                    link_num, len(links)), fg('red'))
-                return
-
-            webbrowser.open(links[link_num - 1])
-
     except Exception as e:
         cprint("{}: please try again later".format(
             type(e).__name__),
             fg('red'))
+
+    if link_num == -1:
+        for link in links:
+            webbrowser.open(link)
+    else:
+        if len(links) < link_num:
+            cprint("Cannot open link {}. Toot contains {} weblinks".format(
+                link_num, len(links)), fg('red'))
+            return
+
+        webbrowser.open(links[link_num - 1])
 
 web.__argstr__ = '<id>'
 web.__section__ = 'Toots'

--- a/src/tootstream/toot_parser.py
+++ b/src/tootstream/toot_parser.py
@@ -282,6 +282,6 @@ class TootParser(HTMLParser):
         return self.links
 
 
-    def get_links(self):
+    def get_weblinks(self):
         """Returns an array of non-mastodon links parsed from the toot."""
         return self.weblinks

--- a/src/tootstream/toot_parser.py
+++ b/src/tootstream/toot_parser.py
@@ -128,6 +128,7 @@ class TootParser(HTMLParser):
         self.fed = []
         self.lines = []
         self.links = []
+        self.weblinks = []
         self.cur_type = None
         self.hide = False
         self.ellipsis = False
@@ -174,6 +175,7 @@ class TootParser(HTMLParser):
             if self.mention_style != None:
                 self.fed.append(self.mention_style)
         else:
+            self.weblinks.append(find_attr('href', attrs))
             self.cur_type = 'link'
             if self.link_style != None:
                 self.fed.append(self.link_style)
@@ -278,3 +280,8 @@ class TootParser(HTMLParser):
     def get_links(self):
         """Returns an array of links parsed from the source HTML toot."""
         return self.links
+
+
+    def get_links(self):
+        """Returns an array of non-mastodon links parsed from the toot."""
+        return self.weblinks


### PR DESCRIPTION
*This pull request is based on #175*

This PR introduces a command `browse <id>`, which lets users open the shareable URL of a toot in their webbrowser. The command has a second form `browse <id> in client`, which opens the toot in the Mastodon web gui of their currently logged in instance.

```
Examples:
        >>> browse 23
        >>> browse 23 in client
```