### PR TITLE
Pleroma-related fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=6.7
-Mastodon.py==1.3
+Mastodon.py==1.3.1
 colored>=1.3.5
 humanize>=0.5.1
 emoji>=0.4.5

--- a/src/tootstream/toot.py
+++ b/src/tootstream/toot.py
@@ -514,6 +514,7 @@ def register_app(instance):
     raises a Mastodon exception otherwise.
     """
     return Mastodon.create_app( 'tootstream',
+                                scopes=['read', 'write', 'follow'],
                                 api_base_url="https://" + instance )
 
 
@@ -533,11 +534,11 @@ def login(instance, client_id, client_secret):
     )
 
     print("Click the link to authorize login.")
-    print(mastodon.auth_request_url())
+    print(mastodon.auth_request_url(scopes=['read', 'write', 'follow']))
     print()
     code = input("Enter the code you received >")
 
-    return mastodon.log_in(code = code)
+    return mastodon.log_in(code = code, scopes=['read', 'write', 'follow'])
 
 
 def get_or_input_profile(config, profile, instance=None):


### PR DESCRIPTION
This PR makes some changes related to how Oauth scopes are handled to enable tootstream to work with Pleroma instances.

Authentication via mastodon.py now involves explicitly specifying scopes. By default, mastodon.py requests *all* scopes: read, write, follow, and push. Since Pleroma does not grant the push scope, asking for the push scope causes an error when trying to auth with Pleroma instances. As tootstream does not actually use the push API, we do not need to ask for this scope at all.

Mastodon.py was also bumped to 1.3.1. This brings in halcy/Mastodon.py#139, which means that existing tokens which asked for push at authentication time should still work fine.