### PR TITLE
Loosen Mastodon.py requirements slightly to allow usage of 1.4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=6.7
-Mastodon.py==1.4.5
+Mastodon.py>=1.4.5,<1.5.0
 colored>=1.3.93
 humanize>=0.5.1
 emoji>=0.4.5


### PR DESCRIPTION
Loosen Mastodon.py requirements slightly to allow usage of 1.4.6 and other versions before 1.5.0